### PR TITLE
[SUGGESTION] Adicionar templates para issues e PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_pt.yml
+++ b/.github/ISSUE_TEMPLATE/bug_pt.yml
@@ -1,0 +1,95 @@
+name: Relatorio de Bug
+description: Reporte um problema ou comportamento inesperado
+title: "[ <<ISSUE_NUMBER>> - [BUG] ] - Titulo do relatorio de bug"
+labels: [bug]
+
+body:
+  - type: textarea
+    attributes:
+      label: 🐛 Descreva o bug
+      description: Uma descricao clara e concisa do bug.
+      placeholder: O que aconteceu?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 🧪 Como reproduzir
+      description: Passos para reproduzir o comportamento.
+      placeholder: |
+        1. Va para '...'
+        2. Clique em '...'
+        3. Role ate '...'
+        4. Veja o erro
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 🎯 Comportamento esperado
+      description: Uma descricao clara e concisa do que deveria acontecer.
+      placeholder: O que deveria ter acontecido?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 📷 Evidencias
+      description: Se aplicavel, adicione capturas de tela para ajudar a explicar o problema.
+      placeholder: Cole imagens ou links aqui.
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: 🖥️ Desktop
+      description: Preencha as informacoes a seguir
+      options:
+        - OS: Windows
+        - OS: macOS
+        - OS: Linux
+        - Outro
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 🖥️ Navegador Desktop
+      placeholder: ex.: Chrome, Safari, Firefox
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 🖥️ Versao do Navegador Desktop
+      placeholder: ex.: 22
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 Dispositivo Smartphone
+      placeholder: ex.: iPhone 6
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 SO do Smartphone
+      placeholder: ex.: iOS 8.1 / Android 13
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 Navegador do Smartphone
+      placeholder: ex.: Safari, Chrome
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 Versao do Navegador do Smartphone
+      placeholder: ex.: 22
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug Report
+description: Report a problem or unexpected behavior
+title: "[ <<ISSUE_NUMBER>> - [BUG] ] - Bug Report title"
+labels: [bug]
+
+body:
+  - type: textarea
+    attributes:
+      label: 🐛 Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 🧪 To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 🎯 Expected behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 📷 Evidences
+      description: If applicable, add screenshots to help explain your problem.
+      placeholder: Paste images or links here.
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: 🖥️ Desktop
+      description: Please complete the following information
+      options:
+        - OS: Windows
+        - OS: macOS
+        - OS: Linux
+        - Other
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 🖥️ Desktop Browser
+      placeholder: e.g. Chrome, Safari, Firefox
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 🖥️ Desktop Browser Version
+      placeholder: e.g. 22
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 Smartphone Device
+      placeholder: e.g. iPhone 6
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 Smartphone OS
+      placeholder: e.g. iOS 8.1 / Android 13
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 Smartphone Browser
+      placeholder: e.g. Safari, Chrome
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: 📱 Smartphone Browser Version
+      placeholder: e.g. 22
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,44 @@
+name: General Issue
+description: Feature, enhancement or general suggestion for the project
+title: "[ <<ISSUE_NUMBER>> - [IDEA] ] - Some title here"
+
+body:
+  - type: textarea
+    attributes:
+      label: 🚀 Description
+      placeholder: |
+        You can describe with a clear and concise description of:
+        * what the problem is
+        * what you want to happen
+        * any alternative solutions or features you've considered
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: ✍️ Context
+      placeholder: |
+        A short description of the context of the task, why it is important and how it fits into the overall project.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: 📝 Tasks
+      placeholder: |
+        - [ ] some task here
+        - [ ] some task here
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 📷 References / 🔗 Attachments
+      placeholder: |
+        You can attach some screenshots or links here.
+        * Desktop
+        * Mobile
+        * Links
+        * [some link]()
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/general_pt.yml
+++ b/.github/ISSUE_TEMPLATE/general_pt.yml
@@ -1,0 +1,44 @@
+name: Issue Geral
+description: Funcionalidade, melhoria ou sugestao geral para o projeto
+title: "[ <<ISSUE_NUMBER>> - [IDEA] ] - algum titulo aqui"
+
+body:
+  - type: textarea
+    attributes:
+      label: 🚀 Descricao
+      placeholder: |
+        Voce pode descrever de forma clara e concisa:
+        * qual e o problema
+        * o que voce quer que aconteca
+        * quaisquer solucoes alternativas ou funcionalidades consideradas
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: ✍️ Contexto
+      placeholder: |
+        Uma breve descricao do contexto da tarefa, por que ela e importante e como ela se encaixa no projeto como um todo.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: 📝 Tarefas
+      placeholder: |
+        - [ ] alguma tarefa aqui
+        - [ ] alguma tarefa aqui
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 📷 Referencias / 🔗 Anexos
+      placeholder: |
+        Voce pode anexar capturas de tela ou links aqui.
+        * Desktop
+        * Mobile
+        * Links
+        * [algum link]()
+    validations:
+      required: false

--- a/.github/pr_template_pt.md
+++ b/.github/pr_template_pt.md
@@ -1,0 +1,14 @@
+fecha #[NUMERO DA ISSUE]
+
+## Descricao
+
+O que este PR faz?
+
+## Anexo
+
+Print ou video do que foi adicionado ou modificado
+
+## Principais Entregas
+
+- [ ] algo aqui
+- [ ] algo aqui

--- a/.github/pr_template_suggestion.md
+++ b/.github/pr_template_suggestion.md
@@ -1,0 +1,36 @@
+<!-- esse aqui é um exemplo de como eu to usando nos meus projetos, caso vc queira reaproveitar a estrutura toda ou apenas um trecho dela -->
+
+_Don't forget to keep title's pattern:_
+
+- _Issue PR: **[CODE-<ISSUE_ID>] + title (PR #<PR_NUMBER>)**_
+- _Sub-issue PR: **[CODE-<ISSUE_ID>][SUB-<SUBISSUE_ID>] + title (PR #<PR_NUMBER>)**_
+
+_Base branch:_
+
+- _Issue PR → `dev`_
+- _Sub-issue PR → parent issue branch (`feat/CODE-<ISSUE_ID>`)_
+
+closes #[issue_number]
+
+### 🚀 Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+### 📷 Evidences
+
+Attach some prints, gifs or videos of the new change
+
+## 🏷️ Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## ☑️ Checklist:
+
+- [ ] I have performed a self-review of my code
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+closes #[ISSUE NUMBER]
+
+## Description
+
+What this PR does?
+
+## Attachment
+
+Print or video of what add or modify
+
+## Main Achievements
+
+- [ ] something here
+- [ ] something here


### PR DESCRIPTION
closes #74 

Esse PR implementa os **templates** de **ISSUES, BUG e PRs.** 
Foi adicionado uma versão extra para PR. 
Foram adicionadas versões em **pt-BR** para **issue, bug e PRs**

Fique à vontade para descartar qualquer uma dessas versões.

Esses arquivos **só funcionarão** na interação dos botões de **"Criar issue"** ou **"Criar PR"** **quando entrarem na master**. Isso é uma regra automática da pasta `.github`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized issue templates for bug reports and general issues in English and Portuguese with structured fields to guide contributors
  * Added standardized pull request templates in English and Portuguese to streamline contribution process
  * Disabled blank issue creation to encourage use of templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->